### PR TITLE
Add WakeGuard Flutter app with QR/NFC alarm disarm

### DIFF
--- a/wake_guard/.gitignore
+++ b/wake_guard/.gitignore
@@ -1,0 +1,20 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+.pub-cache/
+.flutter-plugins
+.flutter-plugins-dependencies
+.melos_tool/
+
+# IntelliJ related
+.idea/
+*.iml
+
+# VS Code related
+.vscode/
+.history/
+
+# Misc
+*.lock
+.DS_Store

--- a/wake_guard/README.md
+++ b/wake_guard/README.md
@@ -1,0 +1,17 @@
+# WakeGuard
+
+WakeGuard ist eine Flutter-App für Android und iOS, die einen Wecker bereitstellt, der nur durch das Scannen eines zuvor hinterlegten QR-Codes oder NFC-Tags deaktiviert werden kann. Das Projekt kombiniert lokale Benachrichtigungen, QR-Scanning und NFC-Funktionen, um hartnäckige Alarme für Morgenmuffel zu ermöglichen.
+
+## Features
+- Wiederholende oder einmalige Alarme einstellen
+- Eigene QR-Codes direkt in der App hinterlegen und anzeigen
+- NFC-Tags registrieren, um den Alarm zu stoppen
+- Vollbild-Alarmanzeige, die erst nach erfolgreichem Scan beendet werden kann
+
+## Getting Started
+1. Installiere die Flutter SDK (3.13 oder höher empfohlen) und führe `flutter pub get` im Projektordner aus.
+2. Für Android: Passe die `android/app/src/main/AndroidManifest.xml` an und aktiviere benötigte Berechtigungen.
+3. Für iOS: Öffne das Projekt in Xcode und aktiviere NFC-Fähigkeiten.
+4. Starte die App mit `flutter run` auf einem angeschlossenen Gerät oder Emulator.
+
+Weitere Details zu Berechtigungen und Konfigurationen findest du in den Kommentaren der jeweiligen Plattform-Dateien.

--- a/wake_guard/analysis_options.yaml
+++ b/wake_guard/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
+    avoid_print: true

--- a/wake_guard/android/app/build.gradle
+++ b/wake_guard/android/app/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.wake_guard'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.wake_guard'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.activity:activity-ktx:1.8.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+}

--- a/wake_guard/android/app/proguard-rules.pro
+++ b/wake_guard/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Flutter recommended proguard rules placeholder

--- a/wake_guard/android/app/src/main/AndroidManifest.xml
+++ b/wake_guard/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.wake_guard">
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+
+    <application
+        android:label="WakeGuard"
+        android:name="io.flutter.app.FlutterApplication"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <service
+            android:name="com.dexterous.flutterlocalnotifications.FlutterLocalNotificationsPlugin"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/wake_guard/android/app/src/main/kotlin/com/example/wake_guard/MainActivity.kt
+++ b/wake_guard/android/app/src/main/kotlin/com/example/wake_guard/MainActivity.kt
@@ -1,0 +1,5 @@
+package com.example.wake_guard
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/wake_guard/android/app/src/main/res/values/styles.xml
+++ b/wake_guard/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,5 @@
+<resources>
+    <style name="LaunchTheme" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowBackground">@android:color/white</item>
+    </style>
+</resources>

--- a/wake_guard/android/build.gradle
+++ b/wake_guard/android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/wake_guard/android/gradle.properties
+++ b/wake_guard/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx4G
+android.useAndroidX=true
+android.enableJetifier=true

--- a/wake_guard/android/gradle/wrapper/gradle-wrapper.jar
+++ b/wake_guard/android/gradle/wrapper/gradle-wrapper.jar
@@ -1,0 +1,16 @@
+<html>
+<head><title>404 Not Found</title></head>
+<body bgcolor="white">
+<center><h1>404 Not Found</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+
+
+

--- a/wake_guard/android/gradle/wrapper/gradle-wrapper.properties
+++ b/wake_guard/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip

--- a/wake_guard/android/gradlew
+++ b/wake_guard/android/gradlew
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_HOME="$(cd "$DIR" && pwd)"
+
+DEFAULT_JVM_OPTS=""
+
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/bin/java" ] ; then
+        JAVACMD="$JAVA_HOME/bin/java"
+    else
+        echo "Error: JAVA_HOME is set to an invalid directory: $JAVA_HOME" >&2
+        exit 1
+    fi
+else
+    JAVACMD="java"
+fi
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+exec "$JAVACMD" $DEFAULT_JVM_OPTS -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/wake_guard/android/gradlew.bat
+++ b/wake_guard/android/gradlew.bat
@@ -1,0 +1,16 @@
+@ECHO OFF
+SET DIR=%~dp0
+SET APP_HOME=%DIR%
+
+SET DEFAULT_JVM_OPTS=
+
+IF NOT "%JAVA_HOME%"=="" (
+  SET JAVA_EXE=%JAVA_HOME%\bin\java.exe
+  IF EXIST "%JAVA_EXE%" goto init
+)
+
+SET JAVA_EXE=java.exe
+
+:init
+SET CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*

--- a/wake_guard/android/settings.gradle
+++ b/wake_guard/android/settings.gradle
@@ -1,0 +1,2 @@
+include ':app'
+rootProject.name = 'wake_guard'

--- a/wake_guard/ios/Runner/AppDelegate.swift
+++ b/wake_guard/ios/Runner/AppDelegate.swift
@@ -1,0 +1,14 @@
+import UIKit
+import Flutter
+import flutter_local_notifications
+
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    GeneratedPluginRegistrant.register(with: self)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}

--- a/wake_guard/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/wake_guard/ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/wake_guard/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json
+++ b/wake_guard/ios/Runner/Assets.xcassets/LaunchImage.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/wake_guard/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/wake_guard/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" systemVersion="18A391" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vc">
+    <scenes>
+        <scene sceneID="scene">
+            <objects>
+                <viewController id="vc" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="view">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="safe"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="responder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/wake_guard/ios/Runner/Base.lproj/Main.storyboard
+++ b/wake_guard/ios/Runner/Base.lproj/Main.storyboard
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" systemVersion="18A391" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vc">
+    <scenes>
+        <scene sceneID="scene">
+            <objects>
+                <viewController id="vc" customClass="FlutterViewController" customModule="Flutter" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="view">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="safe"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="responder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/wake_guard/ios/Runner/Info.plist
+++ b/wake_guard/ios/Runner/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>WakeGuard</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIMainStoryboardFile</key>
+    <string>Main</string>
+    <key>UIRequiresPersistentWiFi</key>
+    <false/>
+    <key>UIStatusBarHidden</key>
+    <false/>
+    <key>UIAppFonts</key>
+    <array/>
+    <key>NSCameraUsageDescription</key>
+    <string>WakeGuard benötigt Zugriff auf die Kamera, um QR-Codes zu scannen.</string>
+    <key>NFCReaderUsageDescription</key>
+    <string>WakeGuard verwendet NFC zum Deaktivieren des Alarms.</string>
+    <key>UIApplicationSupportsIndirectInputEvents</key>
+    <true/>
+</dict>
+</plist>

--- a/wake_guard/lib/main.dart
+++ b/wake_guard/lib/main.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'screens/alarm_ringing_screen.dart';
+import 'screens/home_screen.dart';
+import 'services/alarm_service.dart';
+import 'services/storage_service.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+@pragma('vm:entry-point')
+void notificationTapBackground(NotificationResponse notificationResponse) {
+  debugPrint('Background notification tap: ${notificationResponse.payload}');
+}
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await _configureLocalTimeZone();
+  await StorageService.instance.init();
+  await AlarmService.instance.init(_handleNotificationResponse);
+
+  runApp(const WakeGuardApp());
+}
+
+Future<void> _configureLocalTimeZone() async {
+  tz.initializeTimeZones();
+  final String timeZoneName = await FlutterTimezone.getLocalTimezone();
+  tz.setLocalLocation(tz.getLocation(timeZoneName));
+}
+
+void _handleNotificationResponse(NotificationResponse response) {
+  navigatorKey.currentState?.pushAndRemoveUntil(
+    MaterialPageRoute<void>(
+      builder: (_) => const AlarmRingingScreen(),
+      settings: const RouteSettings(name: AlarmRingingScreen.routeName),
+    ),
+    (route) => false,
+  );
+}
+
+class WakeGuardApp extends StatelessWidget {
+  const WakeGuardApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'WakeGuard',
+      navigatorKey: navigatorKey,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const HomeScreen(),
+      routes: const {
+        AlarmRingingScreen.routeName: AlarmRingingScreen.route,
+      },
+    );
+  }
+}

--- a/wake_guard/lib/screens/alarm_ringing_screen.dart
+++ b/wake_guard/lib/screens/alarm_ringing_screen.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+
+import '../services/alarm_service.dart';
+import '../services/storage_service.dart';
+import '../widgets/qr_preview_dialog.dart';
+
+class AlarmRingingScreen extends StatefulWidget {
+  const AlarmRingingScreen({super.key});
+
+  static const String routeName = '/alarm';
+
+  static Widget route(BuildContext context) => const AlarmRingingScreen();
+
+  @override
+  State<AlarmRingingScreen> createState() => _AlarmRingingScreenState();
+}
+
+class _AlarmRingingScreenState extends State<AlarmRingingScreen> {
+  bool _isDisarmed = false;
+  bool _isProcessing = false;
+  String? _error;
+  QRViewController? _qrController;
+  final GlobalKey _qrKey = GlobalKey(debugLabel: 'ALARM_QR');
+
+  @override
+  void dispose() {
+    _qrController?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _scanQr() async {
+    setState(() {
+      _error = null;
+    });
+
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => AlertDialog(
+        title: const Text('QR-Code scannen'),
+        content: SizedBox(
+          width: 280,
+          height: 280,
+          child: QRView(
+            key: _qrKey,
+            onQRViewCreated: (QRViewController controller) {
+              _qrController = controller;
+              controller.scannedDataStream.listen((Barcode data) async {
+                controller.pauseCamera();
+                final String? expectedCode = StorageService.instance.getQrCode();
+                if (data.code == expectedCode) {
+                  await _finishAlarm();
+                } else {
+                  setState(() {
+                    _error = 'Falscher QR-Code. Versuche es erneut.';
+                  });
+                }
+                if (mounted) Navigator.of(context).pop();
+              });
+            },
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () {
+              _qrController?.dispose();
+              Navigator.of(context).pop();
+            },
+            child: const Text('Abbrechen'),
+          ),
+        ],
+      ),
+    );
+    await _qrController?.resumeCamera();
+  }
+
+  Future<void> _scanNfc() async {
+    setState(() {
+      _isProcessing = true;
+      _error = null;
+    });
+
+    try {
+      final tag = await FlutterNfcKit.poll(timeout: const Duration(seconds: 15));
+      await FlutterNfcKit.finish();
+      final String? expected = StorageService.instance.getNfcIdentifier();
+      if (tag.id == expected) {
+        await _finishAlarm();
+      } else {
+        setState(() {
+          _error = 'Unbekannter Tag erkannt.';
+        });
+      }
+    } on Exception catch (error) {
+      setState(() {
+        _error = 'Fehler beim Lesen: ${error.toString()}';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _finishAlarm() async {
+    await AlarmService.instance.cancelAlarm();
+    if (!mounted) return;
+    setState(() {
+      _isDisarmed = true;
+    });
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final DisarmMethod method = StorageService.instance.getMethod();
+    return Scaffold(
+      backgroundColor: Colors.deepPurple.shade100,
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                const Icon(Icons.alarm, size: 96, color: Colors.deepPurple),
+                const SizedBox(height: 16),
+                Text(
+                  _isDisarmed ? 'Geschafft!' : 'WakeGuard Alarm',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  _isDisarmed
+                      ? 'Du hast den Alarm erfolgreich deaktiviert.'
+                      : method == DisarmMethod.qr
+                          ? 'Scanne den hinterlegten QR-Code, um den Alarm zu stoppen.'
+                          : 'Halte das Gerät an den hinterlegten NFC-Tag, um den Alarm zu stoppen.',
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 24),
+                if (_error != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: Text(
+                      _error!,
+                      style: const TextStyle(color: Colors.red),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                if (!_isDisarmed)
+                  Column(
+                    children: <Widget>[
+                      if (method == DisarmMethod.qr)
+                        FilledButton.icon(
+                          onPressed: _scanQr,
+                          icon: const Icon(Icons.qr_code_scanner),
+                          label: const Text('QR-Code scannen'),
+                        )
+                      else
+                        FilledButton.icon(
+                          onPressed: _isProcessing ? null : _scanNfc,
+                          icon: const Icon(Icons.nfc),
+                          label: Text(
+                            _isProcessing ? 'Scannen...' : 'NFC scannen',
+                          ),
+                        ),
+                      const SizedBox(height: 12),
+                      TextButton(
+                        onPressed: () {
+                          final String? data = method == DisarmMethod.qr
+                              ? StorageService.instance.getQrCode()
+                              : StorageService.instance.getNfcIdentifier();
+                          if (data == null) return;
+                          showDialog<void>(
+                            context: context,
+                            builder: (_) => QrPreviewDialog(
+                              data: data,
+                              title: method == DisarmMethod.qr
+                                  ? 'Hinterlegter QR-Code'
+                                  : 'NFC-Kennung',
+                              description: method == DisarmMethod.qr
+                                  ? 'Nutze diesen Code als Ausdruck.'
+                                  : 'Dies ist die gespeicherte NFC-ID.',
+                              showAsQr: method == DisarmMethod.qr,
+                            ),
+                          );
+                        },
+                        child: const Text('Details anzeigen'),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/wake_guard/lib/screens/home_screen.dart
+++ b/wake_guard/lib/screens/home_screen.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+import '../services/alarm_service.dart';
+import '../services/storage_service.dart';
+import '../widgets/qr_preview_dialog.dart';
+import '../widgets/time_selector.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  TimeOfDay _selectedTime = const TimeOfDay(hour: 7, minute: 0);
+  bool _repeat = false;
+  DisarmMethod _method = DisarmMethod.qr;
+  String? _qrCode;
+  String? _nfcIdentifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSavedValues();
+  }
+
+  Future<void> _loadSavedValues() async {
+    final StorageService storage = StorageService.instance;
+    final TimeOfDay? savedTime = storage.getAlarmTime();
+    final bool repeat = storage.getRepeat();
+    final DisarmMethod method = storage.getMethod();
+    setState(() {
+      _selectedTime = savedTime ?? _selectedTime;
+      _repeat = repeat;
+      _method = method;
+      _qrCode = storage.getQrCode();
+      _nfcIdentifier = storage.getNfcIdentifier();
+    });
+  }
+
+  Future<void> _pickTime(BuildContext context) async {
+    final TimeOfDay? picked = await showTimePicker(
+      context: context,
+      initialTime: _selectedTime,
+      initialEntryMode: TimePickerEntryMode.dial,
+    );
+
+    if (picked != null) {
+      setState(() => _selectedTime = picked);
+      await StorageService.instance.saveAlarmTime(picked);
+    }
+  }
+
+  Future<void> _scheduleAlarm() async {
+    final DateTime now = DateTime.now();
+    DateTime scheduledDate = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      _selectedTime.hour,
+      _selectedTime.minute,
+    );
+
+    if (scheduledDate.isBefore(now)) {
+      scheduledDate = scheduledDate.add(const Duration(days: 1));
+    }
+
+    final tz.TZDateTime tzDate = tz.TZDateTime.from(scheduledDate, tz.local);
+
+    await StorageService.instance.saveRepeat(_repeat);
+    await StorageService.instance.saveMethod(_method);
+
+    await AlarmService.instance.scheduleAlarm(
+      scheduledDate: tzDate,
+      repeats: _repeat,
+    );
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          'Alarm auf ${_selectedTime.format(context)} gesetzt (${_repeat ? 'täglich' : 'einmalig'}).',
+        ),
+      ),
+    );
+  }
+
+  Future<void> _registerQrCode() async {
+    final PermissionStatus status = await Permission.camera.request();
+    if (!status.isGranted) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Kamera-Berechtigung erforderlich.')),
+        );
+      }
+      return;
+    }
+
+    final String? result = await Navigator.of(context).push<String>(
+      MaterialPageRoute<String>(
+        builder: (_) => const _QrScannerScreen(),
+      ),
+    );
+
+    if (result != null) {
+      await StorageService.instance.saveQrCode(result);
+      setState(() => _qrCode = result);
+    }
+  }
+
+  Future<void> _registerNfcTag() async {
+    final PermissionStatus status = await Permission.nfc.request();
+    if (!status.isGranted) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('NFC-Berechtigung erforderlich.')),
+        );
+      }
+      return;
+    }
+
+    if (!mounted) return;
+    final String? identifier = await showDialog<String>(
+      context: context,
+      builder: (_) => const _NfcRegistrationDialog(),
+    );
+
+    if (identifier != null) {
+      await StorageService.instance.saveNfcIdentifier(identifier);
+      setState(() => _nfcIdentifier = identifier);
+    }
+  }
+
+  void _showQrPreview() {
+    if (_qrCode == null) return;
+    showDialog<void>(
+      context: context,
+      builder: (_) => QrPreviewDialog(data: _qrCode!),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('WakeGuard'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: <Widget>[
+            Text('Alarmzeit', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            TimeSelector(
+              time: _selectedTime,
+              onTap: () => _pickTime(context),
+            ),
+            const SizedBox(height: 16),
+            SwitchListTile.adaptive(
+              title: const Text('Täglich wiederholen'),
+              value: _repeat,
+              onChanged: (bool value) {
+                setState(() => _repeat = value);
+                StorageService.instance.saveRepeat(value);
+              },
+            ),
+            const SizedBox(height: 16),
+            Text('Entsperr-Methode', style: textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SegmentedButton<DisarmMethod>(
+              segments: const <ButtonSegment<DisarmMethod>>[
+                ButtonSegment<DisarmMethod>(
+                  value: DisarmMethod.qr,
+                  icon: Icon(Icons.qr_code_2),
+                  label: Text('QR-Code'),
+                ),
+                ButtonSegment<DisarmMethod>(
+                  value: DisarmMethod.nfc,
+                  icon: Icon(Icons.nfc),
+                  label: Text('NFC'),
+                ),
+              ],
+              selected: <DisarmMethod>{_method},
+              onSelectionChanged: (Set<DisarmMethod> value) {
+                setState(() => _method = value.first);
+                StorageService.instance.saveMethod(value.first);
+              },
+            ),
+            const SizedBox(height: 16),
+            if (_method == DisarmMethod.qr)
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.qr_code),
+                  title: Text(_qrCode ?? 'Noch kein QR-Code gespeichert'),
+                  subtitle: const Text('Scanne einen Code, um ihn als Entsperrung zu nutzen.'),
+                  trailing: Wrap(
+                    spacing: 8,
+                    children: <Widget>[
+                      IconButton(
+                        icon: const Icon(Icons.visibility),
+                        onPressed: _qrCode == null ? null : _showQrPreview,
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.qr_code_scanner),
+                        onPressed: _registerQrCode,
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.nfc),
+                  title: Text(
+                    _nfcIdentifier ?? 'Noch kein NFC-Tag registriert',
+                  ),
+                  subtitle: const Text('Halte den gewünschten Tag an das Gerät.'),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.sensors),
+                    onPressed: _registerNfcTag,
+                  ),
+                ),
+              ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: _method == DisarmMethod.qr && _qrCode == null
+                  ? null
+                  : _method == DisarmMethod.nfc && _nfcIdentifier == null
+                      ? null
+                      : _scheduleAlarm,
+              icon: const Icon(Icons.alarm_add),
+              label: const Text('Alarm speichern'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _QrScannerScreen extends StatefulWidget {
+  const _QrScannerScreen({super.key});
+
+  @override
+  State<_QrScannerScreen> createState() => _QrScannerScreenState();
+}
+
+class _QrScannerScreenState extends State<_QrScannerScreen> {
+  QRViewController? _controller;
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+
+  @override
+  void reassemble() {
+    super.reassemble();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      _controller?.pauseCamera();
+    }
+    _controller?.resumeCamera();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('QR-Code scannen')),
+      body: QRView(
+        key: qrKey,
+        onQRViewCreated: _onQRViewCreated,
+      ),
+    );
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    _controller = controller;
+    controller.scannedDataStream.listen((Barcode event) {
+      controller.stopCamera();
+      Navigator.of(context).pop(event.code);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+}
+
+class _NfcRegistrationDialog extends StatefulWidget {
+  const _NfcRegistrationDialog();
+
+  @override
+  State<_NfcRegistrationDialog> createState() => _NfcRegistrationDialogState();
+}
+
+class _NfcRegistrationDialogState extends State<_NfcRegistrationDialog> {
+  bool _isScanning = false;
+  String? _error;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('NFC-Tag registrieren'),
+      content: SizedBox(
+        width: 280,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (_isScanning)
+              const CircularProgressIndicator()
+            else
+              const Icon(Icons.nfc, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              _error ??
+                  (_isScanning
+                      ? 'Halte das Gerät an den Tag...'
+                      : 'Tippe auf Start, um den Tag anzulernen.'),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: _isScanning ? null : () => Navigator.of(context).pop(),
+          child: const Text('Abbrechen'),
+        ),
+        FilledButton(
+          onPressed: _isScanning ? null : _startScanning,
+          child: const Text('Start'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _startScanning() async {
+    setState(() {
+      _isScanning = true;
+      _error = null;
+    });
+
+    try {
+      final tag = await FlutterNfcKit.poll(timeout: const Duration(seconds: 10));
+      await FlutterNfcKit.finish();
+      if (!mounted) return;
+      Navigator.of(context).pop(tag.id);
+    } on Exception catch (error) {
+      setState(() {
+        _error = 'Fehler: ${error.toString()}';
+        _isScanning = false;
+      });
+    }
+  }
+}

--- a/wake_guard/lib/services/alarm_service.dart
+++ b/wake_guard/lib/services/alarm_service.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+class AlarmService {
+  AlarmService._();
+
+  static final AlarmService instance = AlarmService._();
+
+  final FlutterLocalNotificationsPlugin _notificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  static const int _alarmNotificationId = 1001;
+
+  Future<void> init(
+    void Function(NotificationResponse) onNotificationResponse,
+  ) async {
+    const AndroidInitializationSettings androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    const DarwinInitializationSettings iosSettings =
+        DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    final InitializationSettings settings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _notificationsPlugin.initialize(
+      settings,
+      onDidReceiveNotificationResponse: onNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse: notificationTapBackground,
+    );
+  }
+
+  @pragma('vm:entry-point')
+  static void notificationTapBackground(NotificationResponse response) {
+    debugPrint('Notification tapped in background: ${response.payload}');
+  }
+
+  Future<void> scheduleAlarm({
+    required tz.TZDateTime scheduledDate,
+    required bool repeats,
+  }) async {
+    final AndroidNotificationDetails androidDetails =
+        AndroidNotificationDetails(
+      'wake_guard_alarm_channel',
+      'Alarme',
+      channelDescription: 'Benachrichtigungen für WakeGuard Alarme',
+      priority: Priority.high,
+      importance: Importance.max,
+      playSound: true,
+      fullScreenIntent: true,
+      enableVibration: true,
+    );
+
+    const DarwinNotificationDetails iosDetails = DarwinNotificationDetails(
+      presentSound: true,
+      presentAlert: true,
+      interruptionLevel: InterruptionLevel.timeSensitive,
+    );
+
+    final NotificationDetails platformDetails = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notificationsPlugin.zonedSchedule(
+      _alarmNotificationId,
+      'WakeGuard Alarm',
+      'Zeit zum Aufstehen! Scanne den Code zum Stoppen.',
+      scheduledDate,
+      platformDetails,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents:
+          repeats ? DateTimeComponents.time : null,
+    );
+  }
+
+  Future<void> cancelAlarm() async {
+    await _notificationsPlugin.cancel(_alarmNotificationId);
+  }
+}

--- a/wake_guard/lib/services/storage_service.dart
+++ b/wake_guard/lib/services/storage_service.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum DisarmMethod { qr, nfc }
+
+class StorageService {
+  StorageService._();
+
+  static final StorageService instance = StorageService._();
+
+  late SharedPreferences _prefs;
+
+  static const String _qrKey = 'wake_guard_qr_code';
+  static const String _nfcKey = 'wake_guard_nfc_identifier';
+  static const String _timeKey = 'wake_guard_alarm_time';
+  static const String _repeatKey = 'wake_guard_alarm_repeat';
+  static const String _methodKey = 'wake_guard_alarm_method';
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
+
+  Future<void> saveQrCode(String value) async {
+    await _prefs.setString(_qrKey, value);
+  }
+
+  String? getQrCode() => _prefs.getString(_qrKey);
+
+  Future<void> saveNfcIdentifier(String value) async {
+    await _prefs.setString(_nfcKey, value);
+  }
+
+  String? getNfcIdentifier() => _prefs.getString(_nfcKey);
+
+  Future<void> saveAlarmTime(TimeOfDay time) async {
+    final String encoded = '${time.hour}:${time.minute}';
+    await _prefs.setString(_timeKey, encoded);
+  }
+
+  TimeOfDay? getAlarmTime() {
+    final String? encoded = _prefs.getString(_timeKey);
+    if (encoded == null) {
+      return null;
+    }
+    final List<String> parts = encoded.split(':');
+    if (parts.length != 2) {
+      return null;
+    }
+    final int? hour = int.tryParse(parts[0]);
+    final int? minute = int.tryParse(parts[1]);
+    if (hour == null || minute == null) {
+      return null;
+    }
+    return TimeOfDay(hour: hour, minute: minute);
+  }
+
+  Future<void> saveRepeat(bool value) async {
+    await _prefs.setBool(_repeatKey, value);
+  }
+
+  bool getRepeat() => _prefs.getBool(_repeatKey) ?? false;
+
+  Future<void> saveMethod(DisarmMethod method) async {
+    await _prefs.setString(_methodKey, method.name);
+  }
+
+  DisarmMethod getMethod() {
+    final String? value = _prefs.getString(_methodKey);
+    return DisarmMethod.values.firstWhere(
+      (DisarmMethod method) => method.name == value,
+      orElse: () => DisarmMethod.qr,
+    );
+  }
+}

--- a/wake_guard/lib/widgets/qr_preview_dialog.dart
+++ b/wake_guard/lib/widgets/qr_preview_dialog.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class QrPreviewDialog extends StatelessWidget {
+  const QrPreviewDialog({
+    super.key,
+    required this.data,
+    this.title,
+    this.description,
+    this.showAsQr = true,
+  });
+
+  final String data;
+  final String? title;
+  final String? description;
+  final bool showAsQr;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title ?? 'QR-Code Vorschau'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (showAsQr)
+            QrImageView(
+              data: data,
+              size: 220,
+            )
+          else
+            SelectableText(
+              data,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          if (description != null) ...<Widget>[
+            const SizedBox(height: 12),
+            Text(
+              description!,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Schließen'),
+        ),
+      ],
+    );
+  }
+}

--- a/wake_guard/lib/widgets/time_selector.dart
+++ b/wake_guard/lib/widgets/time_selector.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class TimeSelector extends StatelessWidget {
+  const TimeSelector({
+    super.key,
+    required this.time,
+    required this.onTap,
+  });
+
+  final TimeOfDay time;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Theme.of(context).colorScheme.primary),
+        ),
+        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Text(
+              'Geplante Zeit',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Text(
+              time.format(context),
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/wake_guard/pubspec.yaml
+++ b/wake_guard/pubspec.yaml
@@ -1,0 +1,30 @@
+name: wake_guard
+description: Ein Alarm, der nur über einen QR- oder NFC-Scan deaktiviert werden kann.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  flutter_local_notifications: ^17.1.0
+  timezone: ^0.9.2
+  flutter_timezone: ^1.0.6
+  qr_code_scanner: ^1.0.1
+  qr_flutter: ^4.1.0
+  flutter_nfc_kit: ^3.3.0
+  shared_preferences: ^2.3.0
+  permission_handler: ^11.3.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.2
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/

--- a/wake_guard/test/widget_test.dart
+++ b/wake_guard/test/widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('dummy test to ensure test suite runs', () {
+    expect(2 + 2, 4);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold a new Flutter project for WakeGuard including Android and iOS configuration
- implement alarm scheduling with flutter_local_notifications and persistent storage for QR/NFC unlock data
- build UI flows to register QR codes or NFC tags and require scanning to dismiss the ringing alarm

## Testing
- not run (Flutter SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68da1bf761308333ba3609ff08f00aa5